### PR TITLE
Removed a trailing comma

### DIFF
--- a/lib/haml.js
+++ b/lib/haml.js
@@ -342,7 +342,7 @@ var Haml;
           this.contents.join("\n") +
           "\n</style>\n");
       }
-    },
+    }
 
   ];
 


### PR DESCRIPTION
There was an inappropriate comma at the end of an array.
As it apparently might cause problems on IE, it makes it impossible to minify the file with closure.
