### PR TITLE
Added a command-line tool

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,0 +1,19 @@
+
+var Haml = require('haml');
+
+var readUntilEnd = function(stream, callback) {
+    var chunks = [];
+    stream.on('data', function(chunk) {
+        chunks.push(chunk.toString('utf-8'));
+    });
+    stream.on('end', function() {
+        callback(chunks.join(''));
+    });
+}
+
+readUntilEnd(process.openStdin(), function(template) {
+    process.stdout.write(
+                        Haml.optimize(
+                            Haml.compile(
+                                template)));
+});

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
     "description": "Haml ported to server-side Javascript. This is a traditional server-side templating language.",
     "keywords": ["haml", "template"],
     "main" : "./lib/haml",
+    "bin": {
+        "haml-js": "./lib/cli.js"
+    },
     "author": "Tim Caswell <tim@creationix.com>",
     "version": "0.2.5"
 }


### PR DESCRIPTION
<pre>
cat foo.haml | haml-js > foo.js
</pre>


I wrote this because I wanted to easily use haml-js from my app's build script.
