### PR TITLE
Client-side Support

### DIFF
--- a/lib/haml.js
+++ b/lib/haml.js
@@ -4,6 +4,10 @@ var Haml;
 
   var matchers, self_close_tags, embedder, forceXML, escaperName, escapeHtmlByDefault;
 
+  function trim(text){
+  	return text.replace(/^\s+|\s+$/g,"");
+  }
+
   function html_escape(text) {
     return (text + "").
       replace(/&/g, "&amp;").
@@ -71,8 +75,8 @@ var Haml;
       if (typeof pair.start === 'number' &&
           typeof pair.middle === 'number' &&
           typeof pair.end === 'number') {
-        var key = line.substr(pair.start, pair.middle - pair.start).trim(),
-            value = line.substr(pair.middle + 1, pair.end - pair.middle - 1).trim();
+        var key = trim(line.substr(pair.start, pair.middle - pair.start)),
+            value = trim(line.substr(pair.middle + 1, pair.end - pair.middle - 1));
         attributes[key] = value;
       }
       pair = {
@@ -162,7 +166,7 @@ var Haml;
       
       pos += next;
     }
-    return items.filter(function (part) { return part && part.length > 0}).join(" +\n");
+    return _.filter(items, function (part) { return part && part.length > 0}).join(" +\n");
   }
 
   // Used to find embedded code in interpolated strings.
@@ -213,7 +217,7 @@ var Haml;
             attribs._content = attribs._content.substr(leaderLength);
             //once we've identified the tag and its attributes, the rest is content.
             // this is currently trimmed for neatness.
-            this.contents.unshift(attribs._content.trim());
+            this.contents.unshift(trim(attribs._content));
             delete(attribs._content);
           }
         } else {
@@ -221,7 +225,7 @@ var Haml;
         }
 
         if (classes) {
-          classes = classes.map(function (klass) {
+          classes = _.map(classes, function (klass) {
             return klass.substr(1, klass.length);
           }).join(' ');
           if (attribs['class']) {
@@ -235,7 +239,7 @@ var Haml;
           }
         }
         if (ids) {
-          ids = ids.map(function (id) {
+          ids = _.map(ids, function (id) {
             return id.substr(1, id.length);
           }).join(' ');
           if (attribs.id) {
@@ -264,7 +268,7 @@ var Haml;
           }
         }
 
-        if (forceXML ? content.length > 0 : self_close_tags.indexOf(tag) == -1) {
+        if (forceXML ? content.length > 0 : _.indexOf(self_close_tags, tag) == -1) {
           output = '"<' + tag + attribs + '>"' +
             (content.length > 0 ? ' + \n' + content : "") +
             ' + \n"</' + tag + '>"';
@@ -437,25 +441,25 @@ var Haml;
 
     // If lines is a string, turn it into an array
     if (typeof lines === 'string') {
-      lines = lines.trim().replace(/\n\r|\r/g, '\n').split('\n');
+      lines = trim(lines).replace(/\n\r|\r/g, '\n').split('\n');
     }
 
-    lines.forEach(function(line) {
-      var match, found = false;
+    _.each(lines, function(line){
+   	  var match, found = false;
 
       // Collect all text as raw until outdent
       if (block) {
         match = block.check_indent.exec(line);
         if (match) {
-          block.contents.push(match[1] || "");
-          return;
+          block.contents.push(match[1] || ""); 
+          return; 
         } else {
           output.push(block.process());
           block = false;
         }
       }
 
-      matchers.forEach(function (matcher) {
+	  _.each(matchers, function(matcher){
         if (!found) {
           match = matcher.regexp.exec(line);
           if (match) {
@@ -501,19 +505,19 @@ var Haml;
           
           // always escaped
           if((line.substr(0, 2) === "&=")) {
-            line = line.substr(2, line.length).trim();
+            line = trim(line.substr(2, line.length));
             return escapedLine();
           }
           
           //never escaped
           if((line.substr(0, 2) === "!=")) {
-            line = line.substr(2, line.length).trim();
+            line = trim(line.substr(2, line.length));
             return unescapedLine();
           }
           
           // sometimes escaped
           if ( (line[0] === '=')) {
-            line = line.substr(1, line.length).trim();
+            line = trim(line.substr(1, line.length));
             if(escapeHtmlByDefault){
               return escapedLine();
             }else{
@@ -531,7 +535,7 @@ var Haml;
       output.push(block.process());
     }
     
-    var txt = output.filter(function (part) { return part && part.length > 0}).join(" +\n");
+    var txt = _.filter(output, function (part) { return part && part.length > 0}).join(" +\n");
     if(txt.length == 0){
       txt = '""';
     }
@@ -539,7 +543,7 @@ var Haml;
   };
 
   function optimize(js) {
-    var new_js = [], buffer = [], part, end;
+    var new_js = [], buffer = [], part, end; 
 
     function flush() {
       if (buffer.length > 0) {
@@ -547,7 +551,7 @@ var Haml;
         buffer = [];
       }
     }
-    js.replace(/\n\r|\r/g, '\n').split('\n').forEach(function (line) {
+    _.each(js.replace(/\n\r|\r/g, '\n').split('\n'), function (line) {
       part = line.match(/^(\".*\")(\s*\+\s*)?$/);
       if (!part) {
         flush();
@@ -592,7 +596,7 @@ var Haml;
     }).call(self);
   };
 
-  Haml = function Haml(haml, config) {
+  Haml = function (haml, config) {
     if(typeof(config) != "object"){
       forceXML = config;
       config = {};


### PR DESCRIPTION
Here is my fork of haml-js to allow for client-side support (primarily internet explorer)

Outline of changes:
Refactored Array.forEach, Array.indexOf, Array.map, and Array.filter with equivilent underscore.js functions
Refactored String.trim to use internal trim function
Refactored primary Haml signature to exclude 'Haml' from '...function Haml(haml, config) {'
