### PR TITLE
Use browser escape method (if available) to safely escape HTML

### DIFF
--- a/lib/haml.js
+++ b/lib/haml.js
@@ -3,14 +3,15 @@ var Haml;
 (function () {
 
   var matchers, self_close_tags, embedder, forceXML, escaperName, escapeHtmlByDefault;
-
-  function html_escape(text) {
+  var fallback_html_escape = function(text) {
     return (text + "").
       replace(/&/g, "&amp;").
       replace(/</g, "&lt;").
       replace(/>/g, "&gt;").
       replace(/\"/g, "&quot;");
   }
+
+  var html_escape = (window && window.escape) ? window.escape : fallback_html_escape;
 
   function render_attribs(attribs) {
     var key, value, result = [];


### PR DESCRIPTION
Consider using the built-in browser's window.escape method as it is much safer to do.
The built-in html_escape is not safe really safe.

Although it should still falls back if running outside of the browser.
