### PR TITLE
AMD compatibility + hamlint utility

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -306,6 +306,31 @@ If you want to use this project and something is missing then send me a message.
 
 The haml compiler isn't built for speed, it's built for maintainability.  The actual generated templates, however are blazing fast.  I benchmarked them with over 65 million renders per second on a small (20 line) template with some dynamic data on my laptop.  Compare this to the 629 compiles per second I got out of the compiler.  The idea is that you pre-compile your templates and reuse them on every request.  While 629 per second is nothing compared to 65 million, that still means that your server with over 600 different views can boot up in about a second.  I think that's fine for something that only happens every few weeks.
 
+## Emacs flymake mode
+
+haml-js ships with hamlint binary when installed globally using npm. You can easily integrate it in emacs's flymake mode. Just copy paste following lines into your emacs init.el
+
+    (defun flymake-hamlint-init ()
+      (let* ((temp-file (flymake-init-create-temp-buffer-copy
+                         'flymake-create-temp-inplace))
+             (local-file (file-relative-name
+                          temp-file
+                        (file-name-directory buffer-file-name)))
+             (arglist (list local-file)))
+        (list flymake-node-hamlint-program arglist)))
+    (setq flymake-err-line-patterns
+          (cons '(".*:\\([[:digit:]]+\\): \\(.*\\)$"
+                  nil 1 nil 2)
+                flymake-err-line-patterns))
+    (add-to-list 'flymake-allowed-file-name-masks
+                 '("\\.haml\\'" flymake-hamlint-init))
+
+One can decorate the haml file with the first line looking like:
+
+    -#lint-input {context_var1:"",context_var2:""}
+
+This will tell hamlint what context your template is supposed to be run with.
+
 ## License
 
 Haml-js is [licensed][] under the [MIT license][].

--- a/lib/haml.js
+++ b/lib/haml.js
@@ -1,7 +1,15 @@
-var Haml;
- 
-(function () {
-
+if (typeof define !== 'function') {
+    var define = function(f){
+	var Haml = f();
+	// Hook into module system
+	if (typeof module !== 'undefined') {
+	    module.exports = Haml;
+	}
+    };
+}
+define(function () {
+  var Haml;
+  var hamlCache = {};
   var matchers, self_close_tags, embedder, forceXML, escaperName, escapeHtmlByDefault;
 
   function html_escape(text) {
@@ -685,19 +693,32 @@ var Haml;
       var f = new Function("locals",  escaper + str );
       return f;
     }catch(e){
-      if ( typeof(console) !== 'undefined' ) { console.error(str); }
-      throw e;
+      if ( typeof(console) !== 'undefined' ) { console.log(str); console.error(e); }
+      return function() {
+	  return "<div><h1> Error in parsing haml!</h1><p><pre>"+Haml.html_escape(str)+"</pre><p><pre>"+Haml.html_escape(e.toString())+"</pre></div>";
+      }
     }
   }
-
+  /* dojo/requirejs/AMD plugin magic: require( ["haml!./template/mytemplate.haml"], function(template){ ...
+   */
+  function load(resourceDef, require, callback, config) {
+      var url = require.toUrl(resourceDef);
+      if(hamlCache[url]){
+	  return hamlCache[url];
+      }
+      /* use text! plugin to get the associated file so that it work either from browser or node */
+      require (["text!"+resourceDef], function(text){
+	  var js = Haml(text, config);
+	  hamlCache[url] = js;
+	  callback(js);
+      });
+  }
+  
   Haml.compile = compile;
   Haml.optimize = optimize;
   Haml.render = render;
   Haml.execute = execute;
   Haml.html_escape = html_escape;
-}());
-
-// Hook into module system
-if (typeof module !== 'undefined') {
-  module.exports = Haml;
-}
+  Haml.load = load;
+  return Haml;
+});

--- a/lib/hamlint.js
+++ b/lib/hamlint.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+if (process.argv.length != 3) {
+    process.stderr.write("usage: hamlint file.haml\n");
+    process.stderr.write('\nYou can add context information in first line of the file:\n\n');
+    process.stderr.write('-#lint-input {context_var1:"",context_var2:""}\n');
+    process.exit(1);
+}
+var fs = require('fs');
+var fname = process.argv[2];
+allhaml = fs.readFileSync(fname,'utf-8');
+var Haml = require('./haml');
+
+
+var lines = allhaml.split("\n");
+var issues = {};
+var input = "{}";
+var tag = "-#lint-input";
+result = "";
+Haml("");
+var html_escape = function(a){return a;};
+var indent = function(a) { return "    "+a.split("\n").join("\n    ");}
+if (lines[0].indexOf(tag)===0) {
+    issues[0] = "lint input line";
+    try {
+	input = lines[0].substr(tag.length);
+	eval(input);
+    }catch (err) {
+	issues[i] = err;
+	result+=fname+":1: error: "+err;
+    }
+}
+
+try { /* first try to quickly compile the whole file */
+    var js = Haml.optimize(Haml.compile(allhaml));
+    var str = "with("+input+") { "+js+"}";
+    str = eval(str);
+    process.stdout.write("[haml template OK]\n");
+    try { /* if beautifier is installed, we run it.. */
+	str = indent(require("beautifier").html_beautify(str));
+    } catch(err) {}
+    process.stdout.write(str+"\n");
+    process.exit(0);
+} catch (err) {}
+
+for (var i=0;i<lines.length;i+=1) {
+    haml = "";
+    for (var j=0;j<=i;j+=1) {
+	/* skip problematic lines */
+	if (!issues.hasOwnProperty(j)) {
+	    haml+=lines[j]+"\n";
+	}
+    }
+    try {
+	var js = Haml.optimize(Haml.compile(haml));
+	var str = "with("+input+") { "+js+"}";
+	eval(str);
+    }catch (err) {
+	issues[i] = err;
+	result+=fname+":"+(i+1)+": error: "+err+"\n"+indent(js)+"\n";
+    }
+}
+process.stderr.write(result);
+

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "homepage": "https://github.com/creationix/haml-js",
     "main" : "./lib/haml",
     "bin": {
-        "haml-js": "./lib/cli.js"
+        "haml-js": "./lib/cli.js",
+        "hamlint": "./lib/hamlint.js"
     },
     "author": "Aaron Blohowiak <aaron.blohowiak@gmail.com>, Tim Caswell <tim@creationix.com>",
     "version": "0.4.3"


### PR DESCRIPTION
haml-js can also be very good for client side templating.
This pull request adds support for working with requirejs or dojo that use the AMD module model, while still keeping full compatibility with dojo module system.

I also added a hamlint command line utility so that you can detect error in your haml syntax straight from the editor. When the haml looks correct this tool use html_beautifier if it is installed in the system, so that developer can check that generated html looks correct.
