### PR TITLE
Added splat handling

### DIFF
--- a/lib/haml.js
+++ b/lib/haml.js
@@ -15,7 +15,7 @@ var Haml;
   function render_attribs(attribs) {
     var key, value, result = [];
     for (key in attribs) {
-      if (key !== '_content' && attribs.hasOwnProperty(key)) {
+      if (key !== '_content' && key != '_splats' && attribs.hasOwnProperty(key)) {
         switch (attribs[key]) {
         case 'undefined':
         case 'false':
@@ -44,12 +44,13 @@ var Haml;
 
   // Parse the attribute block using a state machine
   function parse_attribs(line) {
-    var attributes = {},
+    var attributes = { _splats: [] },
         l = line.length,
         i, c,
         count = 1,
         quote = false,
         skip = false,
+        splat = false,
         open, close, joiner, seperator,
         pair = {
           start: 1,
@@ -104,18 +105,26 @@ var Haml;
           if (c === '"' || c === "'") {
             quote = c;
           }
+          if (c === '*') {
+            splat = true;
+          }          
 
           if (count === 1) {
             if (c === joiner) {
               pair.middle = i;
             }
-            if (c === seperator || c === close) {
+            if (!splat && (c === seperator || c === close)) {
               pair.end = i;
               process_pair();
               if (c === seperator) {
                 pair.start = i + 1;
               }
             }
+            if (splat && (c === seperator || c === close || c === ' ')) {
+              attributes._splats.push(line.substr(pair.start, i - pair.start).trim().substr(1));
+              splat = false;
+              pair.start = i+1;
+            }            
           }
 
           if (c === open || c === "(") {
@@ -178,7 +187,7 @@ var Haml;
       name: "html tags",
       regexp: /^(\s*)((?:[.#%][a-z_\-][a-z0-9_:\-]*)+)(.*)$/i,
       process: function () {
-        var line_beginning, tag, classes, ids, attribs, content, whitespaceSpecifier, whitespace={}, output;
+        var line_beginning, tag, classes, ids, attribs, splat_code, content, whitespaceSpecifier, whitespace={}, output;
         line_beginning = this.matches[2];
         classes = line_beginning.match(/\.([a-z_\-][a-z0-9_\-]*)/gi);
         ids = line_beginning.match(/\#([a-z_\-][a-z0-9_\-]*)/gi);
@@ -245,6 +254,17 @@ var Haml;
           }
         }
 
+        if (attribs._splats && attribs._splats.length) {
+            var tmp = [],
+                splats = attribs._splats;
+            for(i=0;i<splats.length;i++) {
+              tmp.push('render_splat(' + splats[i] + ')');
+            }
+            splat_code = '"+' + tmp.join('+') + '+"';
+        } else {
+          splat_code = '';
+        }
+
         attribs = render_attribs(attribs);
 
         content = this.render_contents();
@@ -265,11 +285,11 @@ var Haml;
         }
 
         if (forceXML ? content.length > 0 : self_close_tags.indexOf(tag) == -1) {
-          output = '"<' + tag + attribs + '>"' +
+          output = '"<' + tag + attribs + splat_code + '>"' +
             (content.length > 0 ? ' + \n' + content : "") +
             ' + \n"</' + tag + '>"';
         } else {
-          output = '"<' + tag + attribs + ' />"';
+          output = '"<' + tag + attribs + splat_code + ' />"';
         }
         
         if(whitespace.around){
@@ -639,11 +659,41 @@ var Haml;
     return execute(js, options.context || Haml, options.locals);
   };
 
+  function make_render_splat(escaperName) {
+    return new Function('attribs', [
+      "  var key, value, result = [];",
+      "  for (key in attribs) {",
+      "    if (attribs.hasOwnProperty(key)) {",
+      "      switch (attribs[key]) {",
+      "      case undefined:",
+      "      case false:",
+      "      case null:",
+      "      case \"\":",
+      "        break;",
+      "      default:",
+      "        try {",
+      "          value = JSON.parse(\"[\" + attribs[key] +\"]\")[0];",
+      "          if (value === true) {",
+      "            value = key;",
+      "          } else {",
+      "            value = html_escape(value);",
+      "          }",
+      "          result.push(\" \" + key + '=\"' + value + '\"');",
+      "        } catch (e) {",
+      "          result.push(\" \" + key + '=\"' + " + escaperName +"(attribs[key]) + '\"');",
+      "        }",
+      "      }",
+      "    }",
+      "  }",
+      "  return result.join(\"\");"].join('\n'));
+  }
+
   function execute(js, self, locals) {
     return (function () {
       with(locals || {}) {
         try {
           var _$output;
+          var render_splat = make_render_splat((Haml.config && Haml.config.customEscape) ? Haml.config.customEscape : html_escape);
           eval("_$output =" + js );
           return _$output; //set in eval
         } catch (e) {
@@ -682,7 +732,7 @@ var Haml;
     "}"
 
     try{
-      var f = new Function("locals",  escaper + str );
+      var f = new Function("locals",  escaper + 'var render_splat = ' + make_render_splat(escaperName).toString() + ";" + str );
       return f;
     }catch(e){
       if ( typeof(console) !== 'undefined' ) { console.error(str); }

--- a/test/splats.haml
+++ b/test/splats.haml
@@ -1,0 +1,4 @@
+%div.splat{attrib: true, *splat}
+  content
+%div.multi-splat{    *splat1, attrib: true, durr: 'false', derp: null, *splat2,*splat3  }
+  content

--- a/test/splats.html
+++ b/test/splats.html
@@ -1,0 +1,1 @@
+<div attrib="attrib" class="splat" splata="value">content</div><div attrib="attrib" durr="false" class="multi-splat" some-value="value" some-code="&lt;script&gt;var bad = alert();&lt;/script&gt;" bad-code="&quot;&gt;&lt;script&gt;var bad = alert();&lt;/script&gt;" number="123" splata="another value">content</div>

--- a/test/splats.js
+++ b/test/splats.js
@@ -1,0 +1,19 @@
+{
+  locals: {
+    splat: {
+      splata: 'value'
+    },
+    splat1: {
+      'some-value': 'value',
+      'some-code': '<script>var bad = alert();</script>',
+    },
+    splat2: {
+      'bad-code': '"><script>var bad = alert();</script>',
+      number: 123,
+      'a-null': null,
+    },
+    splat3: {
+      splata: 'another value'
+    }
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 var fs = require('fs');
 var assert = require('assert');
-var sys = require('sys');
+var sys = require('util');
 
 var Haml = require("../lib/haml");
 


### PR DESCRIPTION
As per issue #69 I refactored the splat handling into it's own branch and added tests.
All the test pass.

I have several reservations about the code though and I'd like your input:
- the splats maintain only relative order of how they appear in the template, that is they get bunched up in the back of the tag in order they appeared; It may be better that they kept absolute order (ie. if you have a splat before an attribute, then the splat attributes would appear before the attribute in the output)
- the make_render_splat function is a bit of a hack to pass the Haml.compile test, I'm not sure if that's the right way to do that, but I figured that if render_attributes function has the option to use a custom escaper, then render_splats shoul do so too and that's the way it occured to me to code it
- the test pass, but I'm not sure if the code is robust enough
