### PR TITLE
Added optional attributes

### DIFF
--- a/lib/haml.js
+++ b/lib/haml.js
@@ -17,7 +17,7 @@ var Haml;
     for (key in attribs) {
       if (key[key.length - 1] == "?") {
         value = escaperName + '(' + attribs[key] + ')';
-        result.push(' " + ('  + attribs[key] + ' ? "' + key.replace('?', '') + '=\\"" + ' + value + ' + "\\"" : "") + "');
+        result.push('" + ('  + attribs[key] + ' ? " ' + key.replace('?', '') + '=\\"" + ' + value + ' + "\\"" : "") + "');
         continue;
       }
       if (key !== '_content' && attribs.hasOwnProperty(key)) {

--- a/lib/haml.js
+++ b/lib/haml.js
@@ -15,6 +15,11 @@ var Haml;
   function render_attribs(attribs) {
     var key, value, result = [];
     for (key in attribs) {
+      if (key[key.length - 1] == "?") {
+        value = escaperName + '(' + attribs[key] + ')';
+        result.push(' " + ('  + attribs[key] + ' ? "' + key.replace('?', '') + '=\\"" + ' + value + ' + "\\"" : "") + "');
+        continue;
+      }
       if (key !== '_content' && attribs.hasOwnProperty(key)) {
         switch (attribs[key]) {
         case 'undefined':

--- a/test/optional_attribs.haml
+++ b/test/optional_attribs.haml
@@ -1,0 +1,3 @@
+%input{type: "checkbox", disabled?: "disabled", checked?: "checked", readonly?: "readonly"}
+%input{type: "checkbox", disabled?: (5 < 5), checked?: (5 == 5), readonly?: (5 == 5 ? "yes" : false)}
+%input{type: "checkbox", disabled?: (5 < 5), checked?: (5 > 5), readonly?: (5 != 5 ? "yes" : "")}

--- a/test/optional_attribs.html
+++ b/test/optional_attribs.html
@@ -1,0 +1,1 @@
+<input type="checkbox" disabled="disabled" checked="checked" readonly="readonly" /><input type="checkbox" checked="true" readonly="yes" /><input type="checkbox" />


### PR DESCRIPTION
Usage:
```
%input{checked?: model.isChecked(), disabled?: model.isDisabled()}
%input{checked?: model.isChecked(), readonly?: model.isChangable()}
```
this adds these attributes only if model returns "not false" value

For now I have to duplicate such blocks with combinations of these attributes
```
:if (model.isChecked())
  %input{type: "checkbox", ..., checked: true}
:else
  %input{type: "checkbox", ...}
```