### PR TITLE
Officially unsupport multi-line attribute blocks. 

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -33,7 +33,12 @@ Here is the first example(with a little extra added) from the [haml][] site conv
     </div><div id="bio">Experienced software professional...
     </div></div></div></body></html>
 
-Note that this works almost the same as ruby's [haml][], but doesn't pretty print the html.  This would greatly slow down and complicate the code.  If you really want pretty printed html, then I suggest writing one using the xml parser library and process the resulting html..
+Note that this works almost the same as ruby's [haml][], but doesn't pretty print the html.  This would greatly slow down and complicate the code.  If you really want pretty printed html, then I suggest writing one using the xml parser library and process the resulting html.
+
+## Differences from Ruby HAML
+
+* `=` and `-` interpolate JavaScript code, not Ruby 
+* Multi-line attribute blocks are not supported.
 
 ## API
 

--- a/lib/haml.js
+++ b/lib/haml.js
@@ -89,9 +89,10 @@ var Haml;
 
     for (i = 1; count > 0; i += 1) {
 
-      // If we reach the end of the line, then there is a problem
+      // If we reach the end of the line, then there is a problem, or the attribute block is multi-line.
+      // This behavior is unsupported in HAML-js
       if (i > l) {
-        throw "Malformed attribute block";
+        throw "Multi-line attribute blocks are unsupported in HAML-js";
       }
 
       c = line.charAt(i);


### PR DESCRIPTION
Closes [https://github.com/creationix/haml-js/issues/74](https://github.com/creationix/haml-js/issues/74).

HAML-js does not support multiline attribute blocks.
This PR clarifies this fact in several places.

* The error `Malformed attribute block` now reads `Multi-line attribute blocks are unsupported in HAML-js`
* Adds a new section, `Differences from Ruby HAML` to the `Readme`, and notes that:
```markdown
Multi-line attribute blocks are not supported.
```