### PR TITLE
Added ability to handle compile errors

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -98,6 +98,8 @@ Notice how congruent static strings are merged into a single string literal when
 
 Context is the value of `this` in the template, and locals is a hash of local variables.
 
+If `context._err` is a function it will be called with `context._err(error, formatted_error_string)` instead of returning the default formatted error string.
+
 ### Haml.render(text, options) -> html text
 
 This is a convenience function that compiles and executes to html in one shot.  Most casual users will want to use this function exclusively.

--- a/lib/haml.js
+++ b/lib/haml.js
@@ -652,7 +652,9 @@ var Haml;
           eval("_$output =" + js );
           return _$output; //set in eval
         } catch (e) {
-          return "\n<pre class='error'>" + html_escape(e + "\n" + e.stack) + "</pre>\n";
+	  var formatted = "\n<pre class='error'>" + html_escape(e + "\n" + e.stack) + "</pre>\n";
+	  if (typeof self._err === 'function') return self._err(e,formatted);
+          return formatted;
         }
 
       }


### PR DESCRIPTION
See diff for relevant documentation. Errors during `execute` stage will optionally call a handler instead of silently throwing a stack trace to the user.