### PR TITLE
Allow attributes with empty value

### DIFF
--- a/lib/haml.js
+++ b/lib/haml.js
@@ -22,10 +22,12 @@ var Haml;
       }
       if (key !== '_content' && attribs.hasOwnProperty(key)) {
         switch (attribs[key]) {
-        case 'undefined':
         case 'false':
+          break;
+        case 'undefined':
         case 'null':
         case '""':
+          result.push(" " + key);
           break;
         default:
           try {
@@ -79,6 +81,10 @@ var Haml;
         var key = line.substr(pair.start, pair.middle - pair.start).trim(),
             value = line.substr(pair.middle + 1, pair.end - pair.middle - 1).trim();
         attributes[key] = value;
+      }
+      else if (typeof pair.start === 'number' && typeof pair.end === 'number') {
+        var key = line.substr(pair.start, pair.end - pair.start).trim()
+        if (key != "") attributes[key] = ""
       }
       pair = {
         start: null,
@@ -193,6 +199,7 @@ var Haml;
         tag = tag ? tag[0].substr(1, tag[0].length) : 'div';
 
         attribs = this.matches[3];
+        
         if (attribs) {
           attribs = parse_attribs(attribs);
           if (attribs._content) {


### PR DESCRIPTION
Attributes with empty values was not supported until now

`%input(checked)` => `<input checked/>`