### PR TITLE
Multi line support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -223,6 +223,26 @@ The behavior of `=` depends on the setting of the `escapeHtmlByDefault` configur
 
       Haml(src, {escapeHtmlByDefault: true})
 
+## Multi Lines
+Attributes can be declared on multiple lines
+
+      %input(class="foo" 
+        name="test")
+      %input{class: "foo",
+        name: "test"}
+        
+Note the above syntax will not work with empty attributes
+
+      %input(class="foo" 
+        checked           <-- This is not working
+        name="test")
+
+You can also explcilty use the pipe operator `|` just before line break to write content on multiple lines
+
+      %input(        |
+        class="foo"  |
+        name="test"  |
+      )
 ## Plugins
 
 There are plugins in the parser for things like inline script tags, css blocks, and support for if statements and for loops.

--- a/lib/haml.js
+++ b/lib/haml.js
@@ -493,11 +493,23 @@ var Haml;
         output = [],
         ifConditions = [];
 
-    // If lines is a string, turn it into an array
+    // If lines is a string, parse multilines and turn it into an array
     if (typeof lines === 'string') {
-      lines = lines.trim().replace(/\n\r|\r/g, '\n').split('\n');
+      lines = lines.trim()
+      // Multine attributes list, use | as a line breaker
+      lines = lines.replace(/(?<!\|)\|{1}(?!\|)\s*[\n\r]+\s*/g, '')
+      // Multiline attribute list with (attr="value") notation
+      lines = lines.replace(/[\n\r]+\s*([a-zA-Z0-9-:@#_]*=['"])/g, function(c, p1) {
+        return ' ' + p1
+      })
+      // Multiline attribute list with {attr: "value"} notation
+      lines = lines.replace(/,\s*[\n\r]+\s*(['"a-zA-Z0-9-:@#_]*:)/g, function(c, p1) {
+        return ' ' + p1
+      })
+      // Split every line
+      lines = lines.replace(/\n\r|\r/g, '\n').split('\n');
     }
-
+    
     lines.forEach(function(line) {
       var match, found = false;
 


### PR DESCRIPTION
Detect attribute list on multiple lines
Use pipe operator to manually split content over multiple lines